### PR TITLE
[봉찬] 페이지별 레이아웃을 위한 getLayout 구현

### DIFF
--- a/src/components/common/Layout/Main/Header/index.tsx
+++ b/src/components/common/Layout/Main/Header/index.tsx
@@ -1,0 +1,13 @@
+import Nav from '@/components/common/Nav';
+
+export default function Header() {
+  return (
+    <header>
+      <p>서비스 명</p>
+      <div>
+        검색 <input type="search" />
+      </div>
+      <Nav />
+    </header>
+  );
+}

--- a/src/components/common/Layout/Main/index.tsx
+++ b/src/components/common/Layout/Main/index.tsx
@@ -5,7 +5,7 @@ export default function MainLayout({ children }: PropsWithChildren) {
   return (
     <>
       <Header />
-      <main>{children}</main>
+      {children}
     </>
   );
 }

--- a/src/components/common/Layout/Main/index.tsx
+++ b/src/components/common/Layout/Main/index.tsx
@@ -1,0 +1,11 @@
+import { PropsWithChildren } from 'react';
+import Header from './Header';
+
+export default function MainLayout({ children }: PropsWithChildren) {
+  return (
+    <>
+      <Header />
+      <main>{children}</main>
+    </>
+  );
+}

--- a/src/components/common/Nav/Nav.module.scss
+++ b/src/components/common/Nav/Nav.module.scss
@@ -1,0 +1,10 @@
+.container {
+  overflow-x: auto;
+  width: min(100%, 26.875rem);
+}
+
+.nav {
+  display: flex;
+  gap: 0.75rem;
+  white-space: nowrap;
+}

--- a/src/components/common/Nav/index.tsx
+++ b/src/components/common/Nav/index.tsx
@@ -4,13 +4,13 @@ import styles from './Nav.module.scss';
 
 const DUMMY_MENUS = [
   { id: 1, title: 'Home', url: '/' },
-  { id: 2, title: '인기상품', url: '/products/2' },
-  { id: 3, title: 'NEW신상', url: '/products/3' },
-  { id: 4, title: '특가상품', url: '/products/4' },
-  { id: 5, title: '샘플', url: '/products/5' },
-  { id: 6, title: '비밀상점', url: '/products/6' },
-  { id: 7, title: '최저가', url: '/products/7' },
-  { id: 8, title: '이벤트', url: '/events' },
+  { id: 2, title: '인기상품', url: '/test/products/2' },
+  { id: 3, title: 'NEW신상', url: '/test/products/3' },
+  { id: 4, title: '특가상품', url: '/test/products/4' },
+  { id: 5, title: '샘플', url: '/test/products/5' },
+  { id: 6, title: '비밀상점', url: '/test/products/6' },
+  { id: 7, title: '최저가', url: '/test/products/7' },
+  { id: 8, title: '이벤트', url: '/test/events' },
 ];
 
 export default function Nav() {

--- a/src/components/common/Nav/index.tsx
+++ b/src/components/common/Nav/index.tsx
@@ -1,0 +1,30 @@
+import Link from 'next/link';
+
+import styles from './Nav.module.scss';
+
+const DUMMY_MENUS = [
+  { id: 1, title: 'Home', url: '/' },
+  { id: 2, title: '인기상품', url: '/products/2' },
+  { id: 3, title: 'NEW신상', url: '/products/3' },
+  { id: 4, title: '특가상품', url: '/products/4' },
+  { id: 5, title: '샘플', url: '/products/5' },
+  { id: 6, title: '비밀상점', url: '/products/6' },
+  { id: 7, title: '최저가', url: '/products/7' },
+  { id: 8, title: '이벤트', url: '/events' },
+];
+
+export default function Nav() {
+  return (
+    <nav className={styles.container}>
+      <ul className={styles.nav}>
+        {DUMMY_MENUS.map(menu => (
+          <li key={menu.id} className={styles.item}>
+            <Link href={menu.url} className={styles.link}>
+              {menu.title}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,6 +1,27 @@
 import type { AppProps } from 'next/app';
+import { NextPage } from 'next';
+import Head from 'next/head';
+import { ReactElement, ReactNode } from 'react';
+
 import '@/styles/reset.scss';
 
-export default function App({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />;
+type NextPageWithLayout = NextPage & {
+  getLayout?: (page: ReactElement) => ReactNode;
+};
+
+type AppPropsWithLayout = AppProps & {
+  Component: NextPageWithLayout;
+};
+
+export default function App({ Component, pageProps }: AppPropsWithLayout) {
+  const getLayout = Component.getLayout ?? (page => page);
+
+  return (
+    <>
+      <Head>
+        <title>3 team</title>
+      </Head>
+      {getLayout(<Component {...pageProps} />)}
+    </>
+  );
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,14 @@
+import MainLayout from '@/components/common/Layout/Main';
 import styles from './Home.module.scss';
 
 export default function HomePage() {
-  return <h1 className={styles.home}>HomePage</h1>;
+  return (
+    <>
+      <h1 className={styles.home}>HomePage</h1>
+    </>
+  );
 }
+
+HomePage.getLayout = function getLayout(page: React.ReactElement) {
+  return <MainLayout>{page}</MainLayout>;
+};

--- a/src/pages/test/events/index.tsx
+++ b/src/pages/test/events/index.tsx
@@ -1,0 +1,3 @@
+export default function EventsPage() {
+  return <div>EventsPage</div>;
+}

--- a/src/pages/test/products/[productId].tsx
+++ b/src/pages/test/products/[productId].tsx
@@ -1,0 +1,19 @@
+import { NextPageContext } from 'next';
+
+type ProductDetailPageProps = {
+  productId: string;
+};
+
+export default function ProductDetailPage({ productId }: ProductDetailPageProps) {
+  return <h1>[{productId}] ProductDetailPage</h1>;
+}
+
+export async function getServerSideProps(context: NextPageContext) {
+  const { query } = context;
+
+  return {
+    props: {
+      productId: query.productId,
+    },
+  };
+}


### PR DESCRIPTION
## 🔥관련 이슈

- #1 

## :grin:주요 변경 사항
- App 컴포넌트에 getLayout 추가
- Nav, Header, Layout 초안 작업
- 테스트용 페이지 추가

## 📄스크린샷
![스크린샷 2024-05-21 152546](https://github.com/Together-3team/frontend/assets/98067115/f400df21-cd5e-480d-9e53-1ec5e07e0708)


## :pencil:전달사항(세심하게 봐야 할 부분 / 고민점)

- App 컴포넌트의 레이아웃 관련 소스만 집중적으로 봐주시면 될 거 같습니다!
