### PR TITLE
[봉찬] 공통 폰트 mixin 선언

### DIFF
--- a/src/styles/fonts.scss
+++ b/src/styles/fonts.scss
@@ -1,6 +1,104 @@
+/* 폰트 적용 */
 @font-face {
   font-family: 'SUIT Variable';
   font-weight: 100 900;
   font-display: swap;
   src: url('../fonts/SUIT-Variable.woff2') format('woff2-variations');
+}
+
+/* 폰트 스타일 */
+/*
+  사용)
+  .example {
+    @include font-body3;
+
+    color: $color-black;
+  }
+*/
+@mixin font-headline1 {
+  font-family: SUIT;
+  font-size: 2rem;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 2.8rem; /* 140% */
+}
+
+@mixin font-headline2 {
+  font-family: SUIT;
+  font-size: 1.8rem;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 2.4rem; /* 133.333% */
+}
+
+@mixin font-headline3 {
+  font-family: SUIT;
+  font-size: 1.4rem;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 2rem; /* 142.857% */
+}
+
+@mixin font-body1 {
+  font-family: SUIT;
+  font-size: 1.4rem;
+  font-style: normal;
+  font-weight: 600;
+  line-height: 1.8rem; /* 128.571% */
+}
+
+@mixin font-body2 {
+  font-family: SUIT;
+  font-size: 1.4rem;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 1.8rem; /* 128.571% */
+}
+
+@mixin font-body3 {
+  font-family: SUIT;
+  font-size: 1.3rem;
+  font-style: normal;
+  font-weight: 600;
+  line-height: 1.6rem; /* 123.077% */
+}
+
+@mixin font-body4 {
+  font-family: SUIT;
+  font-size: 1.3rem;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 1.6rem; /* 123.077% */
+}
+
+@mixin font-body5 {
+  font-family: SUIT;
+  font-size: 1.2rem;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 1.6rem; /* 133.333% */
+}
+
+@mixin font-body6 {
+  font-family: SUIT;
+  font-size: 1.2rem;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 1.6rem; /* 133.333% */
+}
+
+@mixin font-caption1 {
+  font-family: SUIT;
+  font-size: 1.1rem;
+  font-style: normal;
+  font-weight: 500;
+  line-height: 1.4rem; /* 127.273% */
+}
+
+@mixin font-caption2 {
+  font-family: SUIT;
+  font-size: 1rem;
+  font-style: normal;
+  font-weight: 600;
+  line-height: 1.2rem; /* 120% */
 }

--- a/src/styles/fonts.scss
+++ b/src/styles/fonts.scss
@@ -16,7 +16,6 @@
   }
 */
 @mixin font-headline1 {
-  font-family: 'SUIT Variable';
   font-size: 2rem;
   font-style: normal;
   font-weight: 700;
@@ -24,7 +23,6 @@
 }
 
 @mixin font-headline2 {
-  font-family: 'SUIT Variable';
   font-size: 1.8rem;
   font-style: normal;
   font-weight: 700;
@@ -32,7 +30,6 @@
 }
 
 @mixin font-headline3 {
-  font-family: 'SUIT Variable';
   font-size: 1.4rem;
   font-style: normal;
   font-weight: 700;
@@ -40,7 +37,6 @@
 }
 
 @mixin font-body1 {
-  font-family: 'SUIT Variable';
   font-size: 1.4rem;
   font-style: normal;
   font-weight: 600;
@@ -48,7 +44,6 @@
 }
 
 @mixin font-body2 {
-  font-family: 'SUIT Variable';
   font-size: 1.4rem;
   font-style: normal;
   font-weight: 400;
@@ -56,7 +51,6 @@
 }
 
 @mixin font-body3 {
-  font-family: 'SUIT Variable';
   font-size: 1.3rem;
   font-style: normal;
   font-weight: 600;
@@ -64,7 +58,6 @@
 }
 
 @mixin font-body4 {
-  font-family: 'SUIT Variable';
   font-size: 1.3rem;
   font-style: normal;
   font-weight: 400;
@@ -72,7 +65,6 @@
 }
 
 @mixin font-body5 {
-  font-family: 'SUIT Variable';
   font-size: 1.2rem;
   font-style: normal;
   font-weight: 700;
@@ -80,7 +72,6 @@
 }
 
 @mixin font-body6 {
-  font-family: 'SUIT Variable';
   font-size: 1.2rem;
   font-style: normal;
   font-weight: 400;
@@ -88,7 +79,6 @@
 }
 
 @mixin font-caption1 {
-  font-family: 'SUIT Variable';
   font-size: 1.1rem;
   font-style: normal;
   font-weight: 500;
@@ -96,7 +86,6 @@
 }
 
 @mixin font-caption2 {
-  font-family: 'SUIT Variable';
   font-size: 1rem;
   font-style: normal;
   font-weight: 600;

--- a/src/styles/fonts.scss
+++ b/src/styles/fonts.scss
@@ -16,7 +16,7 @@
   }
 */
 @mixin font-headline1 {
-  font-family: SUIT;
+  font-family: 'SUIT Variable';
   font-size: 2rem;
   font-style: normal;
   font-weight: 700;
@@ -24,7 +24,7 @@
 }
 
 @mixin font-headline2 {
-  font-family: SUIT;
+  font-family: 'SUIT Variable';
   font-size: 1.8rem;
   font-style: normal;
   font-weight: 700;
@@ -32,7 +32,7 @@
 }
 
 @mixin font-headline3 {
-  font-family: SUIT;
+  font-family: 'SUIT Variable';
   font-size: 1.4rem;
   font-style: normal;
   font-weight: 700;
@@ -40,7 +40,7 @@
 }
 
 @mixin font-body1 {
-  font-family: SUIT;
+  font-family: 'SUIT Variable';
   font-size: 1.4rem;
   font-style: normal;
   font-weight: 600;
@@ -48,7 +48,7 @@
 }
 
 @mixin font-body2 {
-  font-family: SUIT;
+  font-family: 'SUIT Variable';
   font-size: 1.4rem;
   font-style: normal;
   font-weight: 400;
@@ -56,7 +56,7 @@
 }
 
 @mixin font-body3 {
-  font-family: SUIT;
+  font-family: 'SUIT Variable';
   font-size: 1.3rem;
   font-style: normal;
   font-weight: 600;
@@ -64,7 +64,7 @@
 }
 
 @mixin font-body4 {
-  font-family: SUIT;
+  font-family: 'SUIT Variable';
   font-size: 1.3rem;
   font-style: normal;
   font-weight: 400;
@@ -72,7 +72,7 @@
 }
 
 @mixin font-body5 {
-  font-family: SUIT;
+  font-family: 'SUIT Variable';
   font-size: 1.2rem;
   font-style: normal;
   font-weight: 700;
@@ -80,7 +80,7 @@
 }
 
 @mixin font-body6 {
-  font-family: SUIT;
+  font-family: 'SUIT Variable';
   font-size: 1.2rem;
   font-style: normal;
   font-weight: 400;
@@ -88,7 +88,7 @@
 }
 
 @mixin font-caption1 {
-  font-family: SUIT;
+  font-family: 'SUIT Variable';
   font-size: 1.1rem;
   font-style: normal;
   font-weight: 500;
@@ -96,7 +96,7 @@
 }
 
 @mixin font-caption2 {
-  font-family: SUIT;
+  font-family: 'SUIT Variable';
   font-size: 1rem;
   font-style: normal;
   font-weight: 600;

--- a/src/styles/reset.scss
+++ b/src/styles/reset.scss
@@ -70,14 +70,11 @@
 
   /* custom reset */
 
-  * {
-    font-family: 'SUIT Variable';
-  }
-
   html {
     /* 62.5% of 16px browser font size is 10px */
     /* 16px * 0.625 = 10px */
     font-size: 62.5%;
+    font-family: 'SUIT Variable';
   }
 
   body {

--- a/src/styles/reset.scss
+++ b/src/styles/reset.scss
@@ -75,6 +75,7 @@
     /* 16px * 0.625 = 10px */
     font-size: 62.5%;
     font-family: 'SUIT Variable';
+    color: $color-black;
   }
 
   body {
@@ -84,6 +85,5 @@
 
   a {
     text-decoration: none;
-    color: black;
   }
 }


### PR DESCRIPTION
## 🔥관련 이슈

- #63 

## :grin:주요 변경 사항

- `fonts.scss`에 피그마에 정의된 공통 폰트를 mixin으로 선언했습니다.

## 📄스크린샷
![스크린샷 2024-05-29 113647](https://github.com/Together-3team/petFrontend/assets/98067115/c265556b-c841-42a0-9f02-041f53df66ff)


## :pencil:전달사항(세심하게 봐야 할 부분 / 고민점)

- 사용 방법은 `fonts.scss`에 적어두었습니다.
```scss
.example {
  @include font-body3;

  color: $color-black;
}
```

## 💌리뷰 작성

칭찬: 👍 / 수정 요청: ❗ / 질문: ❓ / 제안: 💊 / 여담: 💬
