### PR TITLE
[봉찬] 루트 레이아웃 padding 제거

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2179,6 +2179,126 @@
         "glob": "10.3.10"
       }
     },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.3.tgz",
+      "integrity": "sha512-3pEYo/RaGqPP0YzwnlmPN2puaF2WMLM3apt5jLW2fFdXD9+pqcoTzRk+iZsf8ta7+quAe4Q6Ms0nR0SFGFdS1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.3.tgz",
+      "integrity": "sha512-6adp7waE6P1TYFSXpY366xwsOnEXM+y1kgRpjSRVI2CBDOcbRjsJ67Z6EgKIqWIue52d2q/Mx8g9MszARj8IEA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.3.tgz",
+      "integrity": "sha512-cuzCE/1G0ZSnTAHJPUT1rPgQx1w5tzSX7POXSLaS7w2nIUJUD+e25QoXD/hMfxbsT9rslEXugWypJMILBj/QsA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.3.tgz",
+      "integrity": "sha512-0D4/oMM2Y9Ta3nGuCcQN8jjJjmDPYpHX9OJzqk42NZGJocU2MqhBq5tWkJrUQOQY9N+In9xOdymzapM09GeiZw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.3.tgz",
+      "integrity": "sha512-ENPiNnBNDInBLyUU5ii8PMQh+4XLr4pG51tOp6aJ9xqFQ2iRI6IH0Ds2yJkAzNV1CfyagcyzPfROMViS2wOZ9w==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.3.tgz",
+      "integrity": "sha512-BTAbq0LnCbF5MtoM7I/9UeUu/8ZBY0i8SFjUMCbPDOLv+un67e2JgyN4pmgfXBwy/I+RHu8q+k+MCkDN6P9ViQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.3.tgz",
+      "integrity": "sha512-AEHIw/dhAMLNFJFJIJIyOFDzrzI5bAjI9J26gbO5xhAKHYTZ9Or04BesFPXiAYXDNdrwTP2dQceYA4dL1geu8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.3.tgz",
+      "integrity": "sha512-vga40n1q6aYb0CLrM+eEmisfKCR45ixQYXuBXxOOmmoV8sYST9k7E3US32FsY+CkkF7NtzdcebiFT4CHuMSyZw==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@next/swc-win32-x64-msvc": {
       "version": "14.2.3",
       "cpu": [

--- a/src/components/common/Layout/Main/Header/MainHeader.module.scss
+++ b/src/components/common/Layout/Main/Header/MainHeader.module.scss
@@ -1,3 +1,4 @@
 .header {
   width: 100%;
+  padding: 2rem 1.6rem 0;
 }

--- a/src/components/common/Layout/Main/MainLayout.module.scss
+++ b/src/components/common/Layout/Main/MainLayout.module.scss
@@ -2,12 +2,12 @@
   .contents {
     display: flex;
     flex-direction: column;
-    align-items: center;
     width: 100%;
   }
 
   .main {
     position: relative;
+    min-height: 100vh;
   }
 
   .fixedContainer {

--- a/src/components/common/Layout/Root/RootLayout.module.scss
+++ b/src/components/common/Layout/Root/RootLayout.module.scss
@@ -71,6 +71,5 @@
     flex-direction: column;
     width: 100%;
     min-height: 100vh;
-    padding: 2rem 1.6rem;
   }
 }

--- a/src/pages/HomePage.module.scss
+++ b/src/pages/HomePage.module.scss
@@ -1,4 +1,8 @@
 @layer overrides {
+  .container {
+    padding: 0 1.6rem;
+  }
+
   .test {
     border: 1px solid black;
     width: 100%;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,14 +1,10 @@
-import classNames from 'classnames/bind';
-
 import MainLayout from '@/components/common/Layout/Main';
 import styles from './HomePage.module.scss';
 
-const cx = classNames.bind(styles);
-
 export default function HomePage() {
   return (
-    <>
-      <div className={cx('test')}>
+    <div className={styles.container}>
+      <div className={styles.test}>
         <p>
           Ad occaecat officia dolor nulla labore. Eu qui in elit exercitation in nostrud non. Sint sit consequat aliquip
           aliqua. Sint laborum non aliquip adipisicing nisi deserunt pariatur reprehenderit esse elit eu non commodo
@@ -45,7 +41,7 @@ export default function HomePage() {
           sunt adipisicing incididunt enim Lorem qui esse ullamco ullamco officia. Qui et officia esse aute aliqua. Ad
           culpa deserunt minim enim consectetur aliqua aute nisi eiusmod.
         </p>
-        <div className={cx('divider')} />
+        <div className={styles.divider} />
         <p>
           Eiusmod cillum irure excepteur fugiat eiusmod officia in eu. Irure magna incididunt id do consequat
           consectetur anim qui ullamco enim elit. Amet pariatur nulla est Lorem. Anim non qui magna ea do laborum
@@ -89,7 +85,7 @@ export default function HomePage() {
           et.
         </p>
       </div>
-    </>
+    </div>
   );
 }
 


### PR DESCRIPTION
## 🔥관련 이슈

- #73 

## :grin:주요 변경 사항

- RootLayout에 적용된 padding 제거.

## 📄스크린샷
[제거 전]
![스크린샷 2024-05-31 160830](https://github.com/Together-3team/petFrontend/assets/98067115/00d42ad6-f09f-4010-8a51-7fe842aded47)


[제거 후]
![스크린샷 2024-05-31 160849](https://github.com/Together-3team/petFrontend/assets/98067115/1e457c4c-144a-467e-aac8-34e66e0b9ee0)


## :pencil:전달사항(세심하게 봐야 할 부분 / 고민점)

- RootLayout에 padding을 적용하니까 각 페이지에서 사용되는 fixed가 padding 안쪽으로 배치되는 문제 때문에 RootLayout의 padding을 제거했습니다.
- 이번 작업 때문에 앞으로 페이지 작업하실 때 겉에 padding을 넣어주셔야 할 거 같습니다.
- 지금 공통 Nav 및 레이아웃 작업이 늦어지고 있는데 이번 주 안으로 빠르게 처리해서 페이지 작업하실 때 무리 없게 진행하겠습니다.

- AWS 배포 관련해서 추가 작업 진행했고 앞으로 큰 문제는 없을 것으로 보입니다. 다만 지금까지 요금이 5달러 정도 나왔더라구요...? 요금에 대해서는 월요일 회의에서 얘기 나눠봐야 할 거 같습니다!

## 💌리뷰 작성

칭찬: 👍 / 수정 요청: ❗ / 질문: ❓ / 제안: 💊 / 여담: 💬
