### PR TITLE
[서인] 회원가입, 마이 페이지 / 무한 루프 이슈 수정

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -17,7 +17,7 @@ export default function useAuth() {
     enabled: !!accessToken,
   });
 
-  if (!accessToken) {
+  if (!cookie) {
     queryClient.setQueryData(['user'], null);
   }
   const isLogin = !!userData && !!accessToken;

--- a/src/pages/auth/google/callback.tsx
+++ b/src/pages/auth/google/callback.tsx
@@ -16,7 +16,7 @@ export default function GoogleCallback() {
     return response.data;
   }
 
-  const mutation = useMutation<GoogleAuthResponse, Error, void>({
+  const { mutateAsync: mutation } = useMutation<GoogleAuthResponse, Error, void>({
     mutationKey: ['googleAuth'],
     mutationFn: getGoogleAuth,
     onSuccess: (data: GoogleAuthResponse) => {
@@ -42,7 +42,7 @@ export default function GoogleCallback() {
   } as unknown as UseMutationOptions<GoogleAuthResponse, Error, void>);
 
   useEffect(() => {
-    mutation.mutate();
+    mutation();
   }, [mutation]);
 
   return <div></div>;

--- a/src/pages/auth/kakao/callback.tsx
+++ b/src/pages/auth/kakao/callback.tsx
@@ -16,7 +16,7 @@ export default function KakaoCallback() {
     return response.data;
   }
 
-  const mutation = useMutation<KakaoAuthResponse, Error, void>({
+  const { mutateAsync: mutation } = useMutation<KakaoAuthResponse, Error, void>({
     mutationKey: ['kakaoAuth'],
     mutationFn: getKakaoAuth,
     onSuccess: (data: KakaoAuthResponse) => {
@@ -42,7 +42,7 @@ export default function KakaoCallback() {
   } as unknown as UseMutationOptions<KakaoAuthResponse, Error, void>);
 
   useEffect(() => {
-    mutation.mutate();
+    mutation();
   }, [mutation]);
 
   return <div></div>;


### PR DESCRIPTION
## 🔥관련 이슈

- #169 

## :grin:주요 변경 사항

- mutateAsync를 사용해 무한 루프 이슈를 해결했습니다.
- isLogin 판별 조건문을 쿠키 유무로 변경했습니다. accessToken일 때 인식이 잘 안되더라고요... console.log엔 잘 찍히는데...ㅠ

## 📄스크린샷
<img width="410" alt="스크린샷 2024-06-18 오후 1 48 49" src="https://github.com/Together-3team/petFrontend/assets/144193370/df8fb51b-cdc1-4fa2-a272-46652347f66b">
<img width="600" alt="스크린샷 2024-06-18 오후 1 53 32" src="https://github.com/Together-3team/petFrontend/assets/144193370/beba6389-d1e8-4f10-a7f7-4d09c69a1c7e">

## :pencil:전달사항(세심하게 봐야 할 부분 / 고민점)

-
-

## 💌리뷰 작성

칭찬: 👍 / 수정 요청: ❗ / 질문: ❓ / 제안: 💊 / 여담: 💬
