### PR TITLE
[봉찬] 상품 상세 페이지 캐러셀 이미지 error 처리

### DIFF
--- a/src/components/common/Carousel/Product/index.tsx
+++ b/src/components/common/Carousel/Product/index.tsx
@@ -1,3 +1,4 @@
+import { SyntheticEvent } from 'react';
 import Image from 'next/image';
 import useEmblaCarousel from 'embla-carousel-react';
 import Autoplay from 'embla-carousel-autoplay';
@@ -11,7 +12,6 @@ import Mascot from '@/assets/svgs/mascot-share-link.svg';
 import IconX from '@/assets/svgs/ic-x.svg';
 import styles from './ProductCarousel.module.scss';
 import rectangleImg from '@/assets/images/rectangle.png';
-import { SyntheticEvent } from 'react';
 
 interface ProductCarouselProps {
   images: string;

--- a/src/components/common/Carousel/Product/index.tsx
+++ b/src/components/common/Carousel/Product/index.tsx
@@ -10,7 +10,8 @@ import ShareButton from '@/components/common/Button/Share';
 import Mascot from '@/assets/svgs/mascot-share-link.svg';
 import IconX from '@/assets/svgs/ic-x.svg';
 import styles from './ProductCarousel.module.scss';
-import rectangle from '@/assets/images/rectangle.png';
+import rectangleImg from '@/assets/images/rectangle.png';
+import { SyntheticEvent } from 'react';
 
 interface ProductCarouselProps {
   images: string;
@@ -23,7 +24,11 @@ export default function ProductCarousel({ images }: ProductCarouselProps) {
   const { modalOpen, handleModalOpen, handleModalClose } = useModal();
   const { selectedSnap, snapCount } = useSelectedSnapDisplay(emblaApi);
 
-  const items = images !== '' ? images.split(',') : [rectangle.src, rectangle.src];
+  const items = images !== '' ? images.split(',') : [rectangleImg.src, rectangleImg.src];
+
+  const handleImgError = (e: SyntheticEvent<HTMLImageElement, Event>) => {
+    e.currentTarget.src = rectangleImg.src;
+  };
 
   return (
     <>
@@ -38,6 +43,7 @@ export default function ProductCarousel({ images }: ProductCarouselProps) {
                 style={{ objectFit: 'cover' }}
                 sizes="(max-width: 430px) 100vw, 430px"
                 priority
+                onError={handleImgError}
               />
             </div>
           ))}


### PR DESCRIPTION
## 🔥관련 이슈

- #300 

## :grin:주요 변경 사항

- 상품상세 페이지 캐러셀 이미지 error 처리

## 📄스크린샷
[수정 전]
<img src="https://github.com/Together-3team/petFrontend/assets/98067115/75bdc95d-a130-4b19-9b2a-02523673847c" width="60%" />

[수정 후]
<img src="https://github.com/Together-3team/petFrontend/assets/98067115/7b275393-3783-4e9c-969a-351dbea39e99" width="60%" />

## :pencil:전달사항(세심하게 봐야 할 부분 / 고민점)

- DB에 저장된 상품 이미지의 url이 잘 못 들어간 거 같습니다! 일단 회색 이미지로 처리했는데 나중에 귀여운 대체 이미지로 변경하면 될 거 같습니다.

## 💌리뷰 작성

칭찬: 👍 / 수정 요청: ❗ / 질문: ❓ / 제안: 💊 / 여담: 💬
