### PR TITLE
[봉찬] 배너 캐러셀 object-fit: cover 적용

### DIFF
--- a/src/components/common/Carousel/Banner/BannerCarousel.module.scss
+++ b/src/components/common/Carousel/Banner/BannerCarousel.module.scss
@@ -28,5 +28,10 @@
     position: relative;
     flex: 0 0 100%;
     min-width: 0;
+    overflow: hidden;
+  }
+
+  .img {
+    object-fit: cover;
   }
 }

--- a/src/components/common/Carousel/Banner/index.tsx
+++ b/src/components/common/Carousel/Banner/index.tsx
@@ -29,7 +29,7 @@ export default function BannerCarousel() {
       <div className={styles.carousel}>
         {BANNER_IMAGES.map((item, index) => (
           <div key={index} className={styles.slide}>
-            <Image src={item.src} alt={item.alt} fill />
+            <Image className={styles.img} src={item.src} alt={item.alt} fill />
           </div>
         ))}
       </div>


### PR DESCRIPTION
## 🔥관련 이슈

- #303 

## :grin:주요 변경 사항

- 배너 캐러셀 이미지에 `object-fit: cover;` 적용.

## 📄스크린샷
[수정 전]
![배너-이미지-이슈](https://github.com/Together-3team/petFrontend/assets/98067115/a13b5f45-a9ed-4e99-b28b-144206ec2ed0)

[수정 후]
![배너-이미지-해결](https://github.com/Together-3team/petFrontend/assets/98067115/1950bb02-7522-4f7f-a074-9796e34a4ed8)

## :pencil:전달사항(세심하게 봐야 할 부분 / 고민점)

- 영은님께서 피드백 주셔서 반영했습니다. 적용하니까 글씨가 훨씬 선명해져서 좋아요.

## 💌리뷰 작성

칭찬: 👍 / 수정 요청: ❗ / 질문: ❓ / 제안: 💊 / 여담: 💬
