### PR TITLE
[서인] 프로필 수정 / 크로스 브라우징 이슈 해결

### DIFF
--- a/src/pages/my/profile/Profile.module.scss
+++ b/src/pages/my/profile/Profile.module.scss
@@ -33,6 +33,10 @@
     cursor: pointer;
   }
 
+  .profileImage input {
+    display: none;
+  }
+
   .plusButton {
     border: 0;
     background-color: transparent;

--- a/src/pages/my/profile/Profile.module.scss
+++ b/src/pages/my/profile/Profile.module.scss
@@ -99,6 +99,8 @@
     background-color: $color-white;
     color: $color-gray-500;
     border: 0.1rem solid $color-gray-500;
+    cursor: pointer;
+
     @include font-body3;
   }
 

--- a/src/pages/my/profile/Profile.module.scss
+++ b/src/pages/my/profile/Profile.module.scss
@@ -41,8 +41,8 @@
     border: 0;
     background-color: transparent;
     position: absolute;
-    right: 0;
-    bottom: 0;
+    right: -0.5rem;
+    bottom: -0.5rem;
   }
 
   .profileForm {

--- a/src/pages/onboarding/index.tsx
+++ b/src/pages/onboarding/index.tsx
@@ -89,12 +89,12 @@ export default function Onboarding() {
           </h1>
           <div className={styles.petChoice}>
             <div className={styles.petChoiceBox}>
-              <ImageBox
-                size="petPhoto"
-                src={dogChecked ? selectedDog : unselectedDog}
-                alt={dogChecked ? '선택된 강아지 이미지' : '미선택 강아지 이미지'}
-              />
               <label className={styles.petChoiceLabel}>
+                <ImageBox
+                  size="petPhoto"
+                  src={dogChecked ? selectedDog : unselectedDog}
+                  alt={dogChecked ? '선택된 강아지 이미지' : '미선택 강아지 이미지'}
+                />
                 <input
                   type="checkbox"
                   className={styles.checkboxInput}
@@ -109,12 +109,12 @@ export default function Onboarding() {
               </label>
             </div>
             <div className={styles.petChoiceBox}>
-              <ImageBox
-                size="petPhoto"
-                src={catChecked ? selectedCat : unselectedCat}
-                alt={catChecked ? '선택된 고양이 이미지' : '미선택 고양이 이미지'}
-              />
               <label className={styles.petChoiceLabel}>
+                <ImageBox
+                  size="petPhoto"
+                  src={catChecked ? selectedCat : unselectedCat}
+                  alt={catChecked ? '선택된 고양이 이미지' : '미선택 고양이 이미지'}
+                />
                 <input
                   type="checkbox"
                   className={styles.checkboxInput}


### PR DESCRIPTION
## 🔥관련 이슈

- #306 
## :grin:주요 변경 사항

- design: 프로필 삽입 Input css 수정
- design: 플러스 버튼 위치 css 수정
-  design: 프로필 수정 반려동물 선택 버튼 pointer 적용
- refactor: 온보딩 페이지 반려동물 선택 이미지 라벨링

## 📄스크린샷
**<수정 전>**
<img width="422" alt="스크린샷 2024-07-10 오전 1 39 28" src="https://github.com/Together-3team/petFrontend/assets/144193370/6e8c4e22-4553-4891-a18a-c63cf26c1b62">
**<수정 후>**
<img width="921" alt="스크린샷 2024-07-10 오전 1 51 01" src="https://github.com/Together-3team/petFrontend/assets/144193370/cd547561-9f9f-4bde-bb1a-ba1c47838e18">


## :pencil:전달사항(세심하게 봐야 할 부분 / 고민점)

- 프로필 삽입 403에러 떠서 이슈 생성 후 수정하겠습니다.
-

## 💌리뷰 작성

칭찬: 👍 / 수정 요청: ❗ / 질문: ❓ / 제안: 💊 / 여담: 💬
