### PR TITLE
[서인] refreshToken 교체 이슈 수정

### DIFF
--- a/src/apis/axiosInstance.ts
+++ b/src/apis/axiosInstance.ts
@@ -41,6 +41,8 @@ const onRejected = async (error: AxiosError | Error) => {
           const response = await authApi.postToken({ refreshToken });
           const newAccessToken = response.data.accessToken;
 
+          document.cookie = `accessToken=${newAccessToken}; path=/`;
+
           originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
           return authAxiosInstance(originalRequest);
         } catch (refreshError) {

--- a/src/apis/axiosInstance.ts
+++ b/src/apis/axiosInstance.ts
@@ -41,7 +41,9 @@ const onRejected = async (error: AxiosError | Error) => {
           const response = await authApi.postToken({ refreshToken });
           const newAccessToken = response.data.accessToken;
 
-          document.cookie = `accessToken=${newAccessToken}; path=/`;
+          if (!!document) {
+            document.cookie = `accessToken=${newAccessToken}; path=/`;
+          }
 
           originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
           return authAxiosInstance(originalRequest);

--- a/src/pages/my/info/index.tsx
+++ b/src/pages/my/info/index.tsx
@@ -138,7 +138,7 @@ export default function Info() {
               labelStyle={'label'}
               readOnly
               background="background"
-              placeholder={userData.email ?? '이메일을 입력해주세요.'}
+              placeholder={userData?.email ?? '이메일을 입력해주세요.'}
             />
             <Controller
               control={control}

--- a/src/utils/signupFormSchema.ts
+++ b/src/utils/signupFormSchema.ts
@@ -1,7 +1,6 @@
 import { userApi } from '@/apis/userApi';
 import * as Yup from 'yup';
 
-// TODO: 닉네임 중복 검사
 const signupFormSchema = Yup.object().shape({
   nickname: Yup.string()
     .trim()


### PR DESCRIPTION
## 🔥관련 이슈

- #308 

## :grin:주요 변경 사항

- 이슈 원인: accessToken 만료 시 refreshToken 교체 후 쿠키에 저장 안해서 403에러 발생
- 이슈 해결: refreshToken을 쿠키에 저장하는 로직 추가

## 📄스크린샷

## :pencil:전달사항(세심하게 봐야 할 부분 / 고민점)

-
-

## 💌리뷰 작성

칭찬: 👍 / 수정 요청: ❗ / 질문: ❓ / 제안: 💊 / 여담: 💬
