### PR TITLE
[민영] 상품상세보기페이지 공동구매/리뷰 전체보기 기능 수정

### DIFF
--- a/src/components/common/Team/HighlightTeam.module.scss
+++ b/src/components/common/Team/HighlightTeam.module.scss
@@ -34,7 +34,7 @@
   @extend %teamBoxStyle;
 
   padding: 0 1rem;
-  margin: 2.8rem 0 2.4rem;
+  margin-top: 2.8rem;
 }
 
 .participationBtn {
@@ -67,6 +67,7 @@
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   width: 100%;
+  margin-top: 2.4rem;
 }
 
 .noTeamBox {

--- a/src/components/common/Team/HighlightTeam.tsx
+++ b/src/components/common/Team/HighlightTeam.tsx
@@ -20,6 +20,7 @@ interface HighlightTeamProps {
 
 export default function HighlightTeam({ product, showToast }: HighlightTeamProps) {
   const [teamData, setTeamData] = useState<GroupBuyingData[]>([]);
+  const [hasManyTeams, setHasManyTeams] = useState(false);
   const { isLogin } = useAuth();
   const { modalOpen, handleModalOpen, handleModalClose } = useModal();
   const {
@@ -44,6 +45,10 @@ export default function HighlightTeam({ product, showToast }: HighlightTeamProps
       try {
         const response = await httpClient().get<GroupBuyingData[]>(`group-buying/${product.id}`);
         setTeamData(response.slice(0, 3));
+
+        if (response.length > 3) {
+          setHasManyTeams(true);
+        }
       } catch (error) {
         console.log(error);
       }
@@ -77,7 +82,7 @@ export default function HighlightTeam({ product, showToast }: HighlightTeamProps
               <TeamDataCard key={data.id} data={data} product={product} />
             ))}
           </div>
-          {teamData.length > 2 && (
+          {hasManyTeams && (
             <button type="button" className={styles.allTeamLinkBtn} onClick={handleShowAll}>
               참여자 전체보기
             </button>

--- a/src/components/common/Team/HighlightTeam.tsx
+++ b/src/components/common/Team/HighlightTeam.tsx
@@ -77,9 +77,11 @@ export default function HighlightTeam({ product, showToast }: HighlightTeamProps
               <TeamDataCard key={data.id} data={data} product={product} />
             ))}
           </div>
-          <button type="button" className={styles.allTeamLinkBtn} onClick={handleShowAll}>
-            참여자 전체보기
-          </button>
+          {teamData.length > 2 && (
+            <button type="button" className={styles.allTeamLinkBtn} onClick={handleShowAll}>
+              참여자 전체보기
+            </button>
+          )}
         </>
       ) : (
         <div className={styles.noTeamBox}>

--- a/src/components/common/review/HighlightReview.module.scss
+++ b/src/components/common/review/HighlightReview.module.scss
@@ -31,6 +31,10 @@
 .reviewBoxStyle {
   padding: 1.6rem 0;
   border-top: 0.1rem solid $color-gray-200;
+
+  &:last-child {
+    padding: 1.6rem 0 0;
+  }
 }
 
 .allReviewLinkBtn {
@@ -48,6 +52,7 @@
   background-clip: text;
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
+  margin-top: 1.6rem;
 }
 
 .noReview {

--- a/src/components/common/review/HighlightReview.tsx
+++ b/src/components/common/review/HighlightReview.tsx
@@ -49,9 +49,11 @@ export default function HighlightReview({ productId }: HighlightReviewProps) {
               <ReviewBox key={data.id} reviewData={data} className={styles.reviewBoxStyle} />
             ))}
           </div>
-          <Link href={`${productId}/review`} className={styles.allReviewLinkBtn}>
-            리뷰 전체보기
-          </Link>
+          {reviewData.length > 2 && (
+            <Link href={`${productId}/review`} className={styles.allReviewLinkBtn}>
+              리뷰 전체보기
+            </Link>
+          )}
         </>
       ) : (
         <>

--- a/src/components/common/review/HighlightReview.tsx
+++ b/src/components/common/review/HighlightReview.tsx
@@ -27,6 +27,7 @@ export default function HighlightReview({ productId }: HighlightReviewProps) {
         setReviewData(sortedReviews.slice(0, 3));
         setReviewCount(response.reviews.length);
         setAverageRating(response.averageRating.toFixed(1));
+        console.log(reviewData.length);
       } catch (error) {
         console.log(error);
       }
@@ -49,7 +50,7 @@ export default function HighlightReview({ productId }: HighlightReviewProps) {
               <ReviewBox key={data.id} reviewData={data} className={styles.reviewBoxStyle} />
             ))}
           </div>
-          {reviewData.length > 2 && (
+          {reviewCount > 3 && (
             <Link href={`${productId}/review`} className={styles.allReviewLinkBtn}>
               리뷰 전체보기
             </Link>


### PR DESCRIPTION
## 🔥관련 이슈

- #320 

## :grin:주요 변경 사항

- 상품상세보기페이지 공동구매 전체보기 기능 수정
- 상품상세보기페이지 리뷰 전체보기 기능 수정

## 📄스크린샷
### 공동구매 참여자 4팀 이상일 때
<img width="317" alt="스크린샷 2024-10-03 오전 2 35 28" src="https://github.com/user-attachments/assets/35e27496-54db-48db-8bed-9ecfa3a8c000">

### 공동구매 참여자 4팀 미만일 때
<img width="315" alt="스크린샷 2024-10-03 오전 2 35 37" src="https://github.com/user-attachments/assets/05e13d3a-3d2c-4490-99ce-5bcc9408d4f4">

### 리뷰 4개 이상일 때
<img width="307" alt="스크린샷 2024-10-03 오전 2 23 06" src="https://github.com/user-attachments/assets/7bfd1f92-1f25-4ac6-8887-0ab2c1de59eb">

### 리뷰 4개 미만일 때
<img width="314" alt="스크린샷 2024-10-03 오전 2 24 40" src="https://github.com/user-attachments/assets/05d6ac0b-b78c-4977-a290-62fe140d3e47">



## :pencil:전달사항(세심하게 봐야 할 부분 / 고민점)

-
-

## 💌리뷰 작성

칭찬: 👍 / 수정 요청: ❗ / 질문: ❓ / 제안: 💊 / 여담: 💬
